### PR TITLE
patch: prevent ECP params loss

### DIFF
--- a/AppExamples/CleverDeal.React/src/Components/App/App.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/App/App.tsx
@@ -1,14 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
-import { Loading, ThemePicker, HelpButton, LandingPage } from '..';
-import { helpRoom } from '../../Data/deals';
-import { routes } from '../../Data/routes';
-import { FaHome } from 'react-icons/fa';
-import './app.scss';
+import React, { useEffect, useState } from "react";
+import { FaHome } from "react-icons/fa";
+import {
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
+import { HelpButton, LandingPage, Loading, ThemePicker } from "..";
+import { helpRoom } from "../../Data/deals";
+import { routes } from "../../Data/routes";
+import { getEcpParam } from "../../Utils/utils";
+import "./app.scss";
 
 const DEFAULT_ORIGIN: string = "corporate.symphony.com";
-const originInParams = (new URL(window.location.href)).searchParams.get('ecpOrigin');
-const partnerIdInParams = (new URL(window.location.href)).searchParams.get('partnerId');
+const ecpOriginParam = getEcpParam("ecpOrigin") || DEFAULT_ORIGIN;
+const partnerIdParam = getEcpParam("partnerId");
 
 const LargeLoading = () => (
   <div className="large-loading">
@@ -20,18 +27,16 @@ export const App = () => {
   const [ loading, setLoading ] = useState(true);
   const navigate = useNavigate();
   const location = useLocation();
-  const ecpProps = {
-    ecpOrigin: originInParams || DEFAULT_ORIGIN,
-  };
+  const ecpProps = { ecpOrigin: ecpOriginParam };
 
   useEffect(() => {
     const sdkScriptNode = document.createElement('script');
-    sdkScriptNode.src = `https://${originInParams || DEFAULT_ORIGIN}/embed/sdk.js`;
+    sdkScriptNode.src = `https://${ecpOriginParam}/embed/sdk.js`;
     sdkScriptNode.id = 'symphony-ecm-sdk';
     sdkScriptNode.setAttribute('render', 'explicit');
     sdkScriptNode.setAttribute('data-onload', 'renderRoom');
-    if (partnerIdInParams) {
-      sdkScriptNode.setAttribute('data-partner-id', partnerIdInParams);
+    if (partnerIdParam) {
+      sdkScriptNode.setAttribute('data-partner-id', partnerIdParam);
     }
     document.body.appendChild(sdkScriptNode);
 

--- a/AppExamples/CleverDeal.React/src/Utils/utils.js
+++ b/AppExamples/CleverDeal.React/src/Utils/utils.js
@@ -1,0 +1,20 @@
+
+const SS_PREFIX = "cleverdeal::";
+
+/**
+ * Get an ECP param from URL query params and store it in session storage.
+ * If there is no such param in URL, use the one saved in session storage. 
+ * This prevents any ECP param loss after navigating through different URLs.
+ * @param {*} name the ECP param name
+ * @returns the ECP param value
+ */
+export const getEcpParam = (name: string): string | null => {
+    const sessionStorageKey = SS_PREFIX + name;
+
+    const queryParam = new URL(window.location.href).searchParams.get(name);
+    if (queryParam) {
+        sessionStorage.setItem(sessionStorageKey, queryParam);
+        return queryParam;
+    }
+    return sessionStorage.getItem(sessionStorageKey);
+};


### PR DESCRIPTION
**Prevent ECP params loss**

`ecpOrigin` and `partnerId` ECP params are provided through URL query params. When using the brand new routing system,  the query param are lost after a redirection. It means, if we navigate and refresh the page, params will be lost and ECP won't load.

Solution is now to store the ECP params in session storage so that it persists during the navigation.

-------

**Before**

https://github.com/SymphonyPlatformSolutions/ecp-examples/assets/66251236/ee56b04a-c0fa-4e20-8f8c-0fa6350c062e

--------

**After**

https://github.com/SymphonyPlatformSolutions/ecp-examples/assets/66251236/9639d42e-0a55-4e90-a374-e5457b2bfee1