### PR TITLE
BYC-860: Added help improvements

### DIFF
--- a/AppExamples/CleverDeal.React/src/Components/App/App.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/App/App.tsx
@@ -8,7 +8,6 @@ import {
 import { createElement, useEffect, useState, useContext } from "react";
 import { FaHome } from "react-icons/fa";
 import { getEcpParam } from "../../Utils/utils";
-import { helpRoom } from "../../Data/deals";
 import { routes } from "../../Data/routes";
 import { ThemeState, ThemeContext } from '../../Theme/ThemeProvider';
 import HelpButton from "../HelpButton";
@@ -38,6 +37,9 @@ export const App = () => {
   const { applyTheme } = useContext(ThemeContext) as ThemeState;
 
   useEffect(() => {
+    if ((window as any).symphony) {
+      return;
+    }
     const sdkScriptNode = document.createElement("script");
     sdkScriptNode.src = `https://${ecpOriginParam}${sdkPath}`;
     sdkScriptNode.id = "symphony-ecm-sdk";
@@ -59,7 +61,7 @@ export const App = () => {
           applyTheme();
           setLoading(false);
         });
-  }, []);
+  }, [ applyTheme ]);
 
   const getAppLabel = () => {
     const route = routes.find(({ path }) => `/${path}` === location.pathname);
@@ -81,7 +83,7 @@ export const App = () => {
         </div>
         <div className="app-header-settings">
           <ThemePicker />
-          <HelpButton ecpOrigin={ecpProps.ecpOrigin} helpRoom={helpRoom} />
+          <HelpButton ecpOrigin={ecpProps.ecpOrigin} />
         </div>
       </div>
       <Routes>

--- a/AppExamples/CleverDeal.React/src/Components/CleverWealth/CleverWealth.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/CleverWealth/CleverWealth.tsx
@@ -4,7 +4,6 @@ import {
 } from "react-icons/fa6";
 import { FaHome } from "react-icons/fa";
 import { getEcpParam } from "../../Utils/utils";
-import { helpRoom } from "../../Data/deals";
 import { ThemeState, ThemeContext } from '../../Theme/ThemeProvider';
 import { useContext, useEffect, Fragment } from 'react';
 import { wealthData } from "../../Data/wealth";
@@ -136,7 +135,7 @@ export const CleverWealth = () => (
       </div>
       <div className="app-header-settings">
         <ThemePicker />
-        <HelpButton ecpOrigin={ecpOrigin} helpRoom={helpRoom} />
+        <HelpButton ecpOrigin={ecpOrigin} />
       </div>
     </div>
     <WealthApp />

--- a/AppExamples/CleverDeal.React/src/Components/HelpButton/HelpButton.scss
+++ b/AppExamples/CleverDeal.React/src/Components/HelpButton/HelpButton.scss
@@ -1,4 +1,4 @@
-.help-button {
+.button {
     border-width: 0;
     border-radius: 4px;
     font-size: 1rem;
@@ -7,22 +7,29 @@
     padding: .6rem 1rem;
     cursor: pointer;
 }
-.minimised {
+.minimised-bar {
     position: fixed;
     bottom: 0;
     right: 1rem;
-    padding: 1rem;
-    color: var(--on-primary-color);
-    background-color: var(--primary-color);
-    box-shadow: 0 1rem 2rem 0 rgba(0, 0, 0, .3), 0 1rem 3rem 0 rgba(0, 0, 0, .3);
-    z-index: 2;
-    cursor: pointer;
-    user-select: none;
+    display: flex;
+    gap: 1rem;
+
+    .minimised {
+        padding: 1rem;
+        color: var(--on-primary-color);
+        background-color: var(--primary-color);
+        box-shadow:
+            0 1rem 2rem 0 rgba(0, 0, 0, .3),
+            0 1rem 3rem 0 rgba(0, 0, 0, .3);
+        z-index: 2;
+        cursor: pointer;
+        user-select: none;
+    }
 }
 .help-button:hover, .minimised:hover {
     opacity: .8;
 }
-#help-dialog {
+.help-dialog {
     padding: 0;
     border: 0;
     user-select: none;
@@ -31,10 +38,9 @@
     top: 25vh;
     left: 25vw;
     z-index: 2;
-    box-shadow: 0 1rem 2rem 0 rgba(0, 0, 0, .3), 0 1rem 3rem 0 rgba(0, 0, 0, .3);
-}
-#help-dialog::backdrop {
-    background: transparent;
+    box-shadow:
+        0 1rem 2rem 0 rgba(0, 0, 0, .3),
+        0 1rem 3rem 0 rgba(0, 0, 0, .3);
 }
 .app-bar {
     display: flex;
@@ -61,4 +67,18 @@
     width: 50vw;
     height: 50vh;
     overflow: hidden;
+}
+.max-dialog {
+    user-select: none;
+    border-radius: 0.5rem;
+    border: none;
+    color: var(--on-surface-color);
+    border: var(--on-background-color) 2px solid;
+    background-color: var(--surface-color);
+    text-align: center;
+
+    &::backdrop {
+        backdrop-filter: blur(0.5rem);
+    }
+    .button { margin-top: 1rem }
 }

--- a/AppExamples/CleverDeal.React/src/Components/HelpButton/HelpButton.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/HelpButton/HelpButton.tsx
@@ -1,57 +1,145 @@
-import React from "react";
+import "./HelpButton.scss";
+import { botUserId, helpMessages } from "../../Data/help";
+import { useLocation } from "react-router-dom"
+import { useRef, useState } from "react";
 import Draggable from "react-draggable";
-import { RoomIdMap } from "../../Models";
-import './HelpButton.scss';
 
 export interface HelpButtonProps {
-    helpRoom : RoomIdMap;
-    ecpOrigin: string;
-};
+  ecpOrigin: string;
+}
 
-export const HelpButton = (props : HelpButtonProps) => {
-    const dialogRef = React.useRef(null);
-    const minimisedRef = React.useRef(null);
+export const HelpButton = (props: HelpButtonProps) => {
+  const location = useLocation();
+  const maxDialogRef = useRef(null);
+  const [ dialogRefs ] = useState([ useRef(null), useRef(null) ]);
+  const [ minimisedRefs ] = useState([ useRef(null), useRef(null) ]);
+  const [ currentSlot, setCurrentSlot ] = useState(0);
+  const [ chatIndex, setChatIndex ] = useState(1);
+  const [ chatIndexes, setChatIndexes ] = useState([ 0, 0 ]);
 
-    const launchHelp = () => {
-        const dialog = (dialogRef.current as any);
-        if (dialog.open) {
-            dialog.close();
-        } else {
-            dialog.show();
-            (window as any).symphony.openStream(props.helpRoom[props.ecpOrigin], '.help-ecp');
-        }
-    };
-
-    const toggleHelp = () => {
-        const dialog = (dialogRef.current as any);
-        const minimised = (minimisedRef.current as any);
-        dialog.style.visibility = dialog.style.visibility === 'hidden' ? 'visible' : 'hidden';
-        minimised.style.visibility = minimised.style.visibility === 'hidden' ? 'visible' : 'hidden';
-    };
-
+  const helpDialogVisible = () => {
+    const dialog1 = dialogRefs[0].current as any;
+    const dialog2 = dialogRefs[1].current as any;
     return (
-        <>
-            <button
-                className="help-button"
-                onClick={launchHelp}
-            >
-                Help
-            </button>
-            <Draggable nodeRef={dialogRef}>
-                <dialog id="help-dialog" ref={dialogRef}>
-                    <div className="app-bar">
-                        <div>Help</div>
-                        <div className="action-buttons">
-                            <div className="minimise" onClick={toggleHelp}>_</div>
-                            <div className="close" onClick={() => (dialogRef.current as any).close()}>x</div>
-                        </div>
-                    </div>
-                    <div className="help-ecp"></div>
-                </dialog>
-            </Draggable>
-            <div className="minimised" ref={minimisedRef} onClick={toggleHelp} style={{ visibility: 'hidden' }}>
-                Help Chat
-            </div>
-        </>
+      (dialog1.open && dialog1.style.visibility === "visible") ||
+      (dialog2.open && dialog2.style.visibility === "visible")
     );
+  };
+
+  const launchHelp = () => {
+    const isFullCollab = location.pathname === '/wealth';
+
+    if (helpDialogVisible()) {
+      return;
+    }
+    if (currentSlot > 1) {
+      (maxDialogRef.current as any).showModal();
+      return;
+    }
+
+    const updatedChatIndexes = [...chatIndexes];
+    updatedChatIndexes[currentSlot] = chatIndex;
+    setChatIndexes(updatedChatIndexes);
+
+    if (!isFullCollab) {
+      const dialog = dialogRefs[currentSlot].current as any;
+      dialog.show();
+    }
+
+    setCurrentSlot((old) => old + 1);
+    setChatIndex((old) => old + 1);
+
+    const now = new Date();
+    const roomName = `Clever Help ${now.toLocaleDateString()} ${now.toLocaleTimeString()}`;
+    const message = {
+      text: {
+        'text/markdown': '/menu ecp-help-demo-' + helpMessages[location.pathname],
+      },
+    };
+    const options = {
+      message,
+      external: props.ecpOrigin === 'corporate.symphony.com',
+      silent: true,
+    };
+    const botId = botUserId[props.ecpOrigin];
+
+    const symphony = (window as any).symphony;
+    if (!isFullCollab) {
+      symphony.createRoom(roomName, [ botId ], options, `.help-ecp-${currentSlot}`);
+    } else {
+      symphony.createRoom(roomName, [ botId ], options);
+    }
+  };
+
+  const toggleHelp = (slot: number) => {
+    const dialog = dialogRefs[slot].current as any;
+    const minimised = minimisedRefs[slot].current as any;
+    dialog.style.visibility =
+      dialog.style.visibility === "hidden" ? "visible" : "hidden";
+    minimised.style.display =
+      minimised.style.display === "none" ? "block" : "none";
+  };
+
+  const closeHelp = (slot: number) => {
+    const ref: any = dialogRefs[slot].current;
+    if (ref) {
+      ref.close();
+    }
+    setCurrentSlot(slot);
+  };
+
+  const getHelpDialog = (slot: number, ref: any) => (
+    <Draggable nodeRef={ref} key={`dialog-${slot}`}>
+      <dialog className="help-dialog" ref={ref}>
+        <div className="app-bar">
+          <div>Help Chat {chatIndexes[slot]}</div>
+          <div className="action-buttons">
+            <div className="minimise" onClick={() => toggleHelp(slot)}>
+              _
+            </div>
+            <div className="close" onClick={() => closeHelp(slot)}>
+              x
+            </div>
+          </div>
+        </div>
+        <div className={`help-ecp help-ecp-${slot}`}></div>
+      </dialog>
+    </Draggable>
+  );
+
+  const getMinimised = (slot: number, ref: any) => (
+    <div
+      key={`minimised-${slot}`}
+      ref={ref}
+      className="minimised"
+      onClick={() => toggleHelp(slot)}
+      style={{ display: "none" }}
+    >
+      Help Chat {chatIndexes[slot]}
+    </div>
+  );
+
+  return (
+    <>
+      <button className="button" onClick={launchHelp}>
+        Help
+      </button>
+
+      {[1, 0].map((i) => getHelpDialog(i, dialogRefs[i]))}
+
+      <div className="minimised-bar">
+        {[1, 0].map((i) => getMinimised(i, minimisedRefs[i]))}
+      </div>
+
+      <dialog className="max-dialog" ref={maxDialogRef}>
+        <div>You can only have a maximum of 2 help chats open at any time</div>
+        <button
+          className="button"
+          onClick={() => (maxDialogRef.current as any).close()}
+        >
+          OK
+        </button>
+      </dialog>
+    </>
+  );
 };

--- a/AppExamples/CleverDeal.React/src/Data/deals.ts
+++ b/AppExamples/CleverDeal.React/src/Data/deals.ts
@@ -2,7 +2,7 @@ import {
   SYNC_CHART_SCOPE_INTENT,
   Scope,
 } from "../Components/Graph/Graph.utils";
-import { DealInterface, RoomIdMap } from "../Models";
+import { DealInterface } from "../Models";
 
 const yannick = {
   id: "",
@@ -123,11 +123,6 @@ export const INITIAL_DEALS: DealInterface[] = [
   },
   ...generateInactiveDeals(12),
 ];
-
-export const helpRoom: RoomIdMap = {
-  "st3.symphony.com": "+Slk3L9bALdV8EW82EPCfX///ndFonF/dA==",
-  "corporate.symphony.com": "HASQkcT2VaQXxHKFPjFb9H///ndGbRFidA==",
-};
 
 export const getShareScreenshotMessage = (b64Image: string | undefined) => ({
   text: {

--- a/AppExamples/CleverDeal.React/src/Data/help.ts
+++ b/AppExamples/CleverDeal.React/src/Data/help.ts
@@ -1,0 +1,14 @@
+interface UserIdMap extends Record<string, number> {}
+
+export const botUserId : UserIdMap = {
+  "corporate.symphony.com": 70368744179899,
+  "st3.symphony.com": 9139691185433,
+};
+
+export const helpMessages : Record<string, string> = {
+  '/': 'trading',
+  '/investments': 'trading',
+  '/operations': 'ops',
+  '/research': 'research',
+  '/wealth': 'wealth',
+};

--- a/AppExamples/CleverDeal.React/src/Data/operations.ts
+++ b/AppExamples/CleverDeal.React/src/Data/operations.ts
@@ -191,17 +191,24 @@ export const getTradeExceptionRoomName = (tradeException: TradeException) =>
 export const getMessageTable = (
   tradeException: TradeException,
   fields = Object.values(TradeField)
-) => {
-  return `<table>
+) => `<table>
   <thead>
-  <tr>${fields.map((field) => `<th>${TradeFieldLabels[field]}</th>`)}</tr>
+    <tr>
+      <th>Reference</th>
+      <th>${tradeException.entry1.reference}</th>
+      <th>${tradeException.entry2.reference}</th>
+    </tr>
   </thead>
   <tbody>
-  <tr>${fields.map((field) => `<th>${tradeException.entry1[field]}</th>`)}</tr>
-  <tr>${fields.map((field) => `<th>${tradeException.entry2[field]}</th>`)}</tr>
+    ${fields.filter((field) => field !== 'reference').map((field) => (
+      `<tr>
+        <td>${TradeFieldLabels[field]}</td>
+        <td>${tradeException.entry1[field]}</td>
+        <td>${tradeException.entry2[field]}</td>
+      </tr>`
+    )).join('')}
   </tbody>
   </table>`;
-};
 
 export const getTradeExceptionInitialMessage = (
   tradeException: TradeException,
@@ -209,8 +216,11 @@ export const getTradeExceptionInitialMessage = (
 ) => ({
   text: {
     "text/markdown": [
-      `### Trade Exception Resolution`,
-      `A conflict has been detected on field **${TradeFieldLabels[conflictingField]}**.`,
+      `**Trade Exception Resolution**`,
+      '&nbsp;',
+      `Conflict on field **${TradeFieldLabels[conflictingField]}**: *${tradeException.entry1[conflictingField]}* vs *${tradeException.entry2[conflictingField]}*`,
+      'Please select the correct value in the table above this chat',
+      '&nbsp;',
       getMessageTable(tradeException),
     ].join("\n"),
   },


### PR DESCRIPTION
* Replace static room stream ID with create new room (silently)
* Room  name: Clever Help X where X is the current date/time
* Members: Custom Menu Bot (70368744179899) and current user
* Trigger bot with command based on current route:
  * `/` -> `/menu ecp-help-demo-trading`
  * `investments` -> `/menu ecp-help-demo-trading`
  * `operations` -> `/menu ecp-help-demo-ops`
  * `research` -> `/menu ecp-help-demo-research`
  * `wealth` -> `/menu ecp-help-demo-wealth`
* Allow up to 2 help rooms to be created that can be individually minimised or closed
* Closing disposes the room and opens up a slot in the 2 room limit


https://github.com/SymphonyPlatformSolutions/ecp-examples/assets/7151832/d7a11a5a-4f1e-4b96-ab21-46cdb46caa01

