### PR TITLE
Use ECP sendData API in CleverDeal operations page

### DIFF
--- a/AppExamples/CleverDeal.React/README.md
+++ b/AppExamples/CleverDeal.React/README.md
@@ -32,8 +32,14 @@ HTTPS=true yarn start
 
 ## Query params
 
-- `ecpOrigin`: URL of the target pod to be loaded in ECP (supported values are `corporate.symphony.com` [default] and `st3.symphony.com`)
+- `ecpOrigin`: URL of the target pod to be loaded in ECP (supported values are `corporate.symphony.com` [default], `st3.symphony.com` or `preview.symphony.com`)
 - `partnerId`: loads ECP with a given partnerId, useful if your environment has partnership configurations (use partnerId=3 to allow Symphony to be loaded on localhost)
 - `sdkPath`: used to target a specific version of ECP (supported values are `/embed/sdk.js` [default] and `/apps/embed/{tag}/sdk.js`)
-    
 
+### Run against ECP (SFE-Lite) running locally
+
+```sh
+HTTPS=true yarn start
+```
+
+- go to https://localhost:3000/?ecpOrigin=local-dev.symphony.com:9090&sdkPath=/client-bff/sdk.js

--- a/AppExamples/CleverDeal.React/src/Components/CleverOperations/TradeExceptionDashboard/TradeExceptionDetails/TradeExceptionDetails.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/CleverOperations/TradeExceptionDashboard/TradeExceptionDetails/TradeExceptionDetails.tsx
@@ -27,12 +27,14 @@ interface TraceExceptionDetailsProps {
   tradeException: TradeException;
   ecpOrigin: string;
   updateTradeExceptionHandler: (newTradeException: TradeException) => void;
+  sendData: (tradeException: TradeException) => void;
 }
 
 const TradeExceptionDetails = ({
   updateTradeExceptionHandler,
   tradeException,
   ecpOrigin,
+  sendData
 }: TraceExceptionDetailsProps) => {
   const [loadedStreamId, setLoadedStreamId] = useState<string>();
   const [isStreamReady, setIsStreamReady] = useState<boolean>(false);
@@ -145,6 +147,7 @@ const TradeExceptionDetails = ({
       .then((response: EcpApiResponse) => {
         if (response.messages) {
           updateTradeExceptionHandler(newTradeException);
+          sendData(newTradeException);
         }
       });
   };

--- a/AppExamples/CleverDeal.React/src/Components/CleverOperations/TradeExceptionDashboard/TradeExceptionTable/TradeExceptionTable.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/CleverOperations/TradeExceptionDashboard/TradeExceptionTable/TradeExceptionTable.tsx
@@ -36,9 +36,9 @@ const TradeExceptionTable = ({
       </tr>
     </thead>
     <tbody>
-      {tradeExceptions.map((tradeException) => (
+      {tradeExceptions.map((tradeException, index: number) => (
         <TradeExceptionRow
-          key={tradeException.entry1.executingParty}
+          key={`${tradeException.entry1.executingParty}-${index}`}
           isActive={tradeException === selectedException}
           tradeException={tradeException}
           onClick={


### PR DESCRIPTION
# Description

Implements ECP `sendData` API (https://github.com/SymphonyOSF/SFE-Lite/pull/14997) in CleverDeal operations page.

Do not merge before https://github.com/SymphonyOSF/SFE-Lite/pull/16104 goes to production (24.1). It updates the design of the message generated by the `sendData` function. 

This allows to reflect changes from one client to another, when a trade is pending / accepted or rejected for instance:

Uploading Screen Recording 2023-12-05 at 17.29.01.mov…
