### PR TITLE
Introduce `forceUserIds` in trade exceptions

### DIFF
--- a/AppExamples/CleverDeal.React/src/Components/CleverOperations/TradeExceptionDashboard/TradeExceptionDetails/TradeExceptionDetails.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/CleverOperations/TradeExceptionDashboard/TradeExceptionDetails/TradeExceptionDetails.tsx
@@ -79,7 +79,7 @@ const TradeExceptionDetails = ({
       (window as any).symphony
         .createRoom(
           getTradeExceptionRoomName(tradeException),
-          [TRADE_TARGET_SYM_IDS.userId[ecpOrigin]],
+          [tradeException.forceUserIds || TRADE_TARGET_SYM_IDS.userId[ecpOrigin]],
           {
             message: getTradeExceptionInitialMessage(
               tradeException,

--- a/AppExamples/CleverDeal.React/src/Data/operations.ts
+++ b/AppExamples/CleverDeal.React/src/Data/operations.ts
@@ -94,6 +94,7 @@ export const INITIAL_TRADE_EXCEPTIONS: TradeException[] = [
       reference: "I02348237923",
     },
     status: TradeExceptionStatus.UNRESOLVED,
+    forceUserIds: ['70368744179986'],
   },
   {
     entry1: {

--- a/AppExamples/CleverDeal.React/src/Models/TradeException.ts
+++ b/AppExamples/CleverDeal.React/src/Models/TradeException.ts
@@ -64,6 +64,7 @@ export interface TradeException {
   status: TradeExceptionStatus;
   resolution?: TradeExceptionResolution;
   streamId?: RoomIdMap;
+  forceUserIds?: string[];
 }
 
 export interface EcpApiResponse {


### PR DESCRIPTION
Maxime's request: use a different userId for the third trade exception