### PR TITLE
Fix/features 2388

### DIFF
--- a/AppExamples/CleverDeal.React/package.json
+++ b/AppExamples/CleverDeal.React/package.json
@@ -20,7 +20,7 @@
     "react-draggable": "^4.4.5",
     "react-icons": "^4.10.1",
     "react-router-dom": "^6.14.1",
-    "react-scripts": "5.0.0",
+    "react-scripts": "5.0.1",
     "react-select": "^5.2.2",
     "react-tabs": "^4.0.1",
     "recharts": "^2.13.0-alpha.5",

--- a/AppExamples/CleverDeal.React/public/index.html
+++ b/AppExamples/CleverDeal.React/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/AppExamples/CleverDeal.React/src/Components/App/App.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/App/App.tsx
@@ -8,6 +8,7 @@ import {
 import { createElement, useEffect, useState, useContext } from "react";
 import { FaHome } from "react-icons/fa";
 import { getEcpParam } from "../../Utils/utils";
+import { validateEcpOrigin } from "../../Utils/originAllowlist";
 import { routes } from "../../Data/routes";
 import { ThemeState, ThemeContext } from '../../Theme/ThemeProvider';
 import HelpButton from "../HelpButton";
@@ -17,13 +18,11 @@ import ThemePicker from "../ThemePicker";
 import "./app.scss";
 import PodPicker from "../PodPicker";
 
-const DEFAULT_ORIGIN: string = "corporate.symphony.com";
 const DEFAULT_PARTNER_ID: string = "symphony_internal_BYC-XXX";
-const ecpOriginParam = getEcpParam("ecpOrigin") || DEFAULT_ORIGIN;
+const ecpOriginParam = validateEcpOrigin(getEcpParam("ecpOrigin"));
 const partnerIdParam = getEcpParam("partnerId");
 
 const DEFAULT_SDK_PATH: string = "/embed/sdk.js";
-const sdkPath = getEcpParam("sdkPath") || DEFAULT_SDK_PATH;
 
 const LargeLoading = () => (
   <div className="large-loading">
@@ -44,7 +43,7 @@ export const App = () => {
       return;
     }
     const sdkScriptNode = document.createElement("script");
-    sdkScriptNode.src = `https://${ecpOriginParam}${sdkPath}`;
+    sdkScriptNode.src = `https://${ecpOriginParam}${DEFAULT_SDK_PATH}`;
     sdkScriptNode.id = "symphony-ecm-sdk";
     sdkScriptNode.setAttribute("render", "explicit");
     sdkScriptNode.setAttribute("data-onload", "renderRoom");

--- a/AppExamples/CleverDeal.React/src/Components/CleverWealth/CleverWealth.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/CleverWealth/CleverWealth.tsx
@@ -4,6 +4,7 @@ import {
 } from "react-icons/fa6";
 import { FaHome } from "react-icons/fa";
 import { getEcpParam } from "../../Utils/utils";
+import { validateEcpOrigin } from "../../Utils/originAllowlist";
 import { getShareScreenshotMessage } from "../../Data/deals";
 import { Graph, GraphRefType } from "../Graph/Graph";
 import { ThemeState, ThemeContext } from '../../Theme/ThemeProvider';
@@ -17,10 +18,9 @@ import "./CleverWealth.scss";
 import PodPicker from "../PodPicker";
 
 const DEFAULT_PARTNER_ID: string = "symphony_internal_BYC-XXX";
-const ecpOrigin = getEcpParam("ecpOrigin") || "corporate.symphony.com";
+const ecpOrigin = validateEcpOrigin(getEcpParam("ecpOrigin"));
 const partnerId = getEcpParam("partnerId");
 const DEFAULT_SDK_PATH: string = "/embed/sdk.js";
-const sdkPath = getEcpParam("sdkPath") || DEFAULT_SDK_PATH;
 
 interface WealthProps {
   setLoading: (loading : boolean) => void;
@@ -35,7 +35,7 @@ const WealthApp = ({ setLoading } : WealthProps) => {
       return;
     }
     const sdkScriptNode = document.createElement("script");
-    sdkScriptNode.src = `https://${ecpOrigin}${sdkPath}`;
+    sdkScriptNode.src = `https://${ecpOrigin}${DEFAULT_SDK_PATH}`;
     sdkScriptNode.id = "symphony-ecm-sdk";
     sdkScriptNode.setAttribute("render", "explicit");
     sdkScriptNode.setAttribute("data-mode", "full");

--- a/AppExamples/CleverDeal.React/src/Components/LandingPage/LandingPage.scss
+++ b/AppExamples/CleverDeal.React/src/Components/LandingPage/LandingPage.scss
@@ -28,6 +28,7 @@
   display: flex;
   flex-direction: column;
   min-width: 10rem;
+  max-width: 10rem;
   min-height: 10rem;
   border: var(--on-background-color) 2px solid;
   border-radius: .5rem;

--- a/AppExamples/CleverDeal.React/src/Components/PodPicker/PodPicker.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/PodPicker/PodPicker.tsx
@@ -2,18 +2,27 @@ import { useEffect, useState, useMemo } from 'react';
 import Select from 'react-select';
 import './PodPicker.scss';
 import { getEcpParam } from '../../Utils/utils';
+import { ALLOWED_ORIGINS } from '../../Utils/originAllowlist';
 
 type OptionType = {
   value?: string
   label?: string
 }
 
+const POD_LABELS: Record<string, string> = {
+  'corporate.symphony.com': 'Corporate',
+  'preview.symphony.com': 'Preview',
+  'st3.dev.symphony.com': 'ST3',
+  'develop2.symphony.com': 'Develop2',
+};
+
 export const PodPicker = () => {
-  const options : OptionType[] = useMemo(() => [
-    { label: 'Corporate', value: 'corporate.symphony.com' },
-    { label: 'Preview', value: 'preview.symphony.com' },
-    { label: 'ST3', value: 'st3.dev.symphony.com' },
-  ], []);
+  const options : OptionType[] = useMemo(() =>
+    ALLOWED_ORIGINS.map(origin => ({
+      label: POD_LABELS[origin] || origin,
+      value: origin,
+    })),
+  []);
   const [ origin, setOrigin ] = useState<OptionType | null | undefined>(options[0]);
 
   useEffect(() => {

--- a/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/symphonySdk.ts
+++ b/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/symphonySdk.ts
@@ -1,4 +1,5 @@
 import { debugWealth } from './wealthDebug';
+import { validateEcpOrigin } from '../../../Utils/originAllowlist';
 
 const SDK_SCRIPT_ID = 'symphony-ecm-sdk';
 const SDK_ONLOAD_CALLBACK = '__wealthManagementRenderEcp';
@@ -450,6 +451,7 @@ export class SymphonySdkService {
   }
 
   init(ecpOrigin: string, partnerId?: string): Promise<void> {
+    const validatedOrigin = validateEcpOrigin(ecpOrigin);
     if (this._status === 'ready') {
       debugSdk('init() skipped — already ready.');
       return Promise.resolve();
@@ -462,7 +464,7 @@ export class SymphonySdkService {
 
     const initStart = performance.now();
     debugSdk('init() starting.', {
-      ecpOrigin,
+      ecpOrigin: validatedOrigin,
       partnerId,
       hasSymphonyOnWindow: Boolean(window.symphony),
       hasExistingScript: Boolean(document.getElementById(SDK_SCRIPT_ID)),
@@ -512,7 +514,7 @@ export class SymphonySdkService {
       }
 
       const script = document.createElement('script');
-      script.src = `https://${ecpOrigin}${DEFAULT_SDK_PATH}`;
+      script.src = `https://${validatedOrigin}${DEFAULT_SDK_PATH}`;
       script.id = SDK_SCRIPT_ID;
       script.setAttribute('render', 'explicit');
       script.setAttribute('data-onload', SDK_ONLOAD_CALLBACK);
@@ -521,7 +523,7 @@ export class SymphonySdkService {
 
       if (partnerId) {
         script.setAttribute('data-partner-id', partnerId);
-      } else if (ecpOrigin !== 'st3.dev.symphony.com') {
+      } else if (validatedOrigin !== 'st3.dev.symphony.com') {
         script.setAttribute('data-partner-id', DEFAULT_PARTNER_ID);
       }
 

--- a/AppExamples/CleverDeal.React/src/Data/routes.ts
+++ b/AppExamples/CleverDeal.React/src/Data/routes.ts
@@ -1,7 +1,6 @@
 import CleverInvestments from "../Components/CleverInvestments";
 import CleverOperations from "../Components/CleverOperations";
 import CleverResearch from "../Components/CleverResearch";
-import CleverWealth from "../Components/CleverWealth";
 import ContentDistribution from "../Components/ContentDistribution";
 import WealthManagementRoute from "../Components/WealthManagement/WealthManagementRoute";
 
@@ -16,7 +15,6 @@ export const routes: AppEntry[] = [
   { label: "Investments",      path: "investments",      component: CleverInvestments },
   { label: "Operations",       path: "operations",       component: CleverOperations },
   { label: "Research",         path: "research",         component: CleverResearch },
-  { label: "Wealth",           path: "wealth",           component: CleverWealth },
-  { label: "Content",          path: "content",          component: ContentDistribution },
   { label: "Wealth Management", path: "wealth-management", routePath: "wealth-management/*", component: WealthManagementRoute, enabled: true },
+  { label: "Content",          path: "content",          component: ContentDistribution },
 ];

--- a/AppExamples/CleverDeal.React/src/Utils/originAllowlist.ts
+++ b/AppExamples/CleverDeal.React/src/Utils/originAllowlist.ts
@@ -1,0 +1,15 @@
+const DEFAULT_ORIGIN = 'corporate.symphony.com';
+
+export const ALLOWED_ORIGINS: readonly string[] = [
+  'corporate.symphony.com',
+  'preview.symphony.com',
+  'st3.dev.symphony.com',
+  'develop2.symphony.com',
+];
+
+export const validateEcpOrigin = (origin: string | null): string => {
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    return origin;
+  }
+  return DEFAULT_ORIGIN;
+};

--- a/AppExamples/CleverDeal.React/src/Utils/utils.js
+++ b/AppExamples/CleverDeal.React/src/Utils/utils.js
@@ -1,3 +1,4 @@
+import { validateEcpOrigin } from './originAllowlist';
 
 const SS_PREFIX = "cleverdeal::";
 
@@ -5,13 +6,24 @@ const SS_PREFIX = "cleverdeal::";
  * Get an ECP param from URL query params and store it in session storage.
  * If there is no such param in URL, use the one saved in session storage.
  * This prevents any ECP param loss after navigating through different URLs.
+ * Security: ecpOrigin values are validated against an allowlist before storage.
  * @param {*} name the ECP param name
  * @returns the ECP param value
  */
 export const getEcpParam = (name: string): string | null => {
     const sessionStorageKey = SS_PREFIX + name;
 
-    const queryParam = new URL(window.location.href).searchParams.get(name);
+    let queryParam = new URL(window.location.href).searchParams.get(name);
+
+    if (name === 'ecpOrigin') {
+        if (queryParam) {
+            queryParam = validateEcpOrigin(queryParam);
+        }
+        const stored = sessionStorage.getItem(sessionStorageKey);
+        if (stored && stored !== validateEcpOrigin(stored)) {
+            sessionStorage.removeItem(sessionStorageKey);
+        }
+    }
 
     if (queryParam) {
         sessionStorage.setItem(sessionStorageKey, queryParam);

--- a/AppExamples/CleverDeal.React/vercel.json
+++ b/AppExamples/CleverDeal.React/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;"
+        }
+      ]
+    }
+  ]
+}

--- a/AppExamples/CleverDealFDC3.React/public/index.html
+++ b/AppExamples/CleverDealFDC3.React/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/AppExamples/CleverDealFDC3.React/src/index.tsx
+++ b/AppExamples/CleverDealFDC3.React/src/index.tsx
@@ -5,7 +5,9 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 const DEFAULT_ORIGIN: string = "corporate.symphony.com";
-const originInParams = (new URL(window.location.href)).searchParams.get('ecpOrigin');
+const ALLOWED_ORIGINS = ['corporate.symphony.com', 'preview.symphony.com', 'st3.dev.symphony.com', 'develop2.symphony.com'];
+const rawOrigin = (new URL(window.location.href)).searchParams.get('ecpOrigin');
+const originInParams = rawOrigin && ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
 
 const loadSdk = (
 ): Promise<void> => {

--- a/AppExamples/EcpOpenSdk/public/index.html
+++ b/AppExamples/EcpOpenSdk/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; style-src 'self' https://cdn.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
 
     <title>ECP Open SDK example</title>
 

--- a/SimpleExamples/src/index-iframe.html
+++ b/SimpleExamples/src/index-iframe.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -47,9 +48,11 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "develop2.symphony.com";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
       function buildFrameUrl(streamId, userIds) {
         const locationUrl = new URL(location.href);
-        const sdkOrigin = locationUrl.searchParams.get("origin");
+        const rawOrigin = locationUrl.searchParams.get("origin");
+        const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
         const BASE_URL = `https://${
           sdkOrigin || DEFAULT_ORIGIN
         }/embed/index.html`;

--- a/SimpleExamples/src/index-multiple-chats.html
+++ b/SimpleExamples/src/index-multiple-chats.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -108,8 +109,10 @@
 
       const loadScript = () => {
         const DEFAULT_ORIGIN = "develop2.symphony.com";
+        const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
         const locationUrl = new URL(location.href);
-        const sdkOrigin = locationUrl.searchParams.get("origin");
+        const rawOrigin = locationUrl.searchParams.get("origin");
+        const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
         const script = document.createElement("script");
         script.id = "symphony-ecm-sdk";
         script.src = `https://${sdkOrigin || DEFAULT_ORIGIN}/embed/sdk.js`;

--- a/SimpleExamples/src/index-notifications.html
+++ b/SimpleExamples/src/index-notifications.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -91,8 +92,10 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "develop2.symphony.com";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
       const locationUrl = new URL(location.href);
-      const sdkOrigin = locationUrl.searchParams.get("origin");
+      const rawOrigin = locationUrl.searchParams.get("origin");
+      const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
 
       document
         .getElementById("ecp-form")

--- a/SimpleExamples/src/index-sdk-automatic.html
+++ b/SimpleExamples/src/index-sdk-automatic.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -72,8 +73,10 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "develop2.symphony.com";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
       const locationUrl = new URL(location.href);
-      const sdkOrigin = locationUrl.searchParams.get("origin");
+      const rawOrigin = locationUrl.searchParams.get("origin");
+      const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
       function cleanDOM(frameContainer) {
         frameContainer.removeAttribute("data-stream-id");
         frameContainer.removeAttribute("data-user-ids");

--- a/SimpleExamples/src/index-sdk-checkAuth.html
+++ b/SimpleExamples/src/index-sdk-checkAuth.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -81,8 +82,10 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "develop2.symphony.com";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
       const locationUrl = new URL(location.href);
-      const sdkOrigin = locationUrl.searchParams.get("origin");
+      const rawOrigin = locationUrl.searchParams.get("origin");
+      const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
 
       document
         .getElementById("ecp-form")

--- a/SimpleExamples/src/index-sdk-explicit.html
+++ b/SimpleExamples/src/index-sdk-explicit.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
 
@@ -90,8 +91,10 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "develop2.symphony.com";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
       const locationUrl = new URL(location.href);
-      const sdkOrigin = locationUrl.searchParams.get("origin");
+      const rawOrigin = locationUrl.searchParams.get("origin");
+      const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
 
       document
         .getElementById("ecp-form")

--- a/SimpleExamples/src/index-sdk-prefetch.html
+++ b/SimpleExamples/src/index-sdk-prefetch.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -107,8 +108,10 @@
 
       const loadScript = () => {
         const DEFAULT_ORIGIN = "develop2.symphony.com";
+        const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
         const locationUrl = new URL(location.href);
-        const sdkOrigin = locationUrl.searchParams.get("origin");
+        const rawOrigin = locationUrl.searchParams.get("origin");
+        const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
         const script = document.createElement("script");
         script.id = "symphony-ecm-sdk";
         script.src = `https://${sdkOrigin || DEFAULT_ORIGIN}/embed/sdk.js`;

--- a/SimpleExamples/src/index-theme.html
+++ b/SimpleExamples/src/index-theme.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -120,8 +121,10 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "local-dev.symphony.com:9090";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com", "local-dev.symphony.com:9090"];
       const locationUrl = new URL(location.href);
-      const sdkOrigin = locationUrl.searchParams.get("origin");
+      const rawOrigin = locationUrl.searchParams.get("origin");
+      const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
       document
         .getElementById("ecp-form")
         .addEventListener("submit", (event) => {


### PR DESCRIPTION
 ## Summary

Mitigates a chained Open Redirect + Script Injection vulnerability where the ecpOrigin URL parameter was used unvalidated in dynamically created <script> tags, allowing arbitrary JavaScript execution.

### Changes
**Security fixes**
- Origin allowlist — New originAllowlist.ts module with explicit ALLOWED_ORIGINS array and validateEcpOrigin() helper. All ecpOrigin usage validated in App.tsx, CleverWealth.tsx, symphonySdk.ts, and utils.js
- sdkPath param removed — Was only used for development and served as an injection vector. All consumers now use the hardcoded DEFAULT_SDK_PATH constant
- SessionStorage sanitization — Poisoned ecpOrigin values are cleared from sessionStorage on read, preventing persistence of injected origins across navigations
- Content-Security-Policy — CSP meta tags added to all HTML entry points (CleverDeal.React, CleverDealFDC3.React, EcpOpenSdk, all SimpleExamples). CSP header added via vercel.json for production
- PodPicker — Options now derived from the shared ALLOWED_ORIGINS array
- SimpleExamples — All 8 HTML files validated against an inline allowlist
- CleverDealFDC3 — ecpOrigin validated in app entry point

**Other changes**
- Bump react-scripts 5.0.0 → 5.0.1
- Remove legacy "Wealth" tile from landing page, reposition "Wealth Management" to its slot
- Constrain tile max-width for consistent label wrapping