### PR TITLE
Fix CSP to allow TradingView widget scripts

### DIFF
--- a/AppExamples/CleverDeal.React/package.json
+++ b/AppExamples/CleverDeal.React/package.json
@@ -20,7 +20,7 @@
     "react-draggable": "^4.4.5",
     "react-icons": "^4.10.1",
     "react-router-dom": "^6.14.1",
-    "react-scripts": "5.0.0",
+    "react-scripts": "5.0.1",
     "react-select": "^5.2.2",
     "react-tabs": "^4.0.1",
     "recharts": "^2.13.0-alpha.5",

--- a/AppExamples/CleverDeal.React/public/index.html
+++ b/AppExamples/CleverDeal.React/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/AppExamples/CleverDeal.React/public/index.html
+++ b/AppExamples/CleverDeal.React/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com https://widgets.tradingview-widget.com 'unsafe-inline'; frame-src https://*.symphony.com https://*.tradingview-widget.com https://*.tradingview.com;" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/AppExamples/CleverDeal.React/src/Components/App/App.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/App/App.tsx
@@ -8,6 +8,7 @@ import {
 import { createElement, useEffect, useState, useContext } from "react";
 import { FaHome } from "react-icons/fa";
 import { getEcpParam } from "../../Utils/utils";
+import { validateEcpOrigin } from "../../Utils/originAllowlist";
 import { routes } from "../../Data/routes";
 import { ThemeState, ThemeContext } from '../../Theme/ThemeProvider';
 import HelpButton from "../HelpButton";
@@ -17,13 +18,11 @@ import ThemePicker from "../ThemePicker";
 import "./app.scss";
 import PodPicker from "../PodPicker";
 
-const DEFAULT_ORIGIN: string = "corporate.symphony.com";
 const DEFAULT_PARTNER_ID: string = "symphony_internal_BYC-XXX";
-const ecpOriginParam = getEcpParam("ecpOrigin") || DEFAULT_ORIGIN;
+const ecpOriginParam = validateEcpOrigin(getEcpParam("ecpOrigin"));
 const partnerIdParam = getEcpParam("partnerId");
 
 const DEFAULT_SDK_PATH: string = "/embed/sdk.js";
-const sdkPath = getEcpParam("sdkPath") || DEFAULT_SDK_PATH;
 
 const LargeLoading = () => (
   <div className="large-loading">
@@ -44,7 +43,7 @@ export const App = () => {
       return;
     }
     const sdkScriptNode = document.createElement("script");
-    sdkScriptNode.src = `https://${ecpOriginParam}${sdkPath}`;
+    sdkScriptNode.src = `https://${ecpOriginParam}${DEFAULT_SDK_PATH}`;
     sdkScriptNode.id = "symphony-ecm-sdk";
     sdkScriptNode.setAttribute("render", "explicit");
     sdkScriptNode.setAttribute("data-onload", "renderRoom");

--- a/AppExamples/CleverDeal.React/src/Components/CleverWealth/CleverWealth.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/CleverWealth/CleverWealth.tsx
@@ -4,6 +4,7 @@ import {
 } from "react-icons/fa6";
 import { FaHome } from "react-icons/fa";
 import { getEcpParam } from "../../Utils/utils";
+import { validateEcpOrigin } from "../../Utils/originAllowlist";
 import { getShareScreenshotMessage } from "../../Data/deals";
 import { Graph, GraphRefType } from "../Graph/Graph";
 import { ThemeState, ThemeContext } from '../../Theme/ThemeProvider';
@@ -17,10 +18,9 @@ import "./CleverWealth.scss";
 import PodPicker from "../PodPicker";
 
 const DEFAULT_PARTNER_ID: string = "symphony_internal_BYC-XXX";
-const ecpOrigin = getEcpParam("ecpOrigin") || "corporate.symphony.com";
+const ecpOrigin = validateEcpOrigin(getEcpParam("ecpOrigin"));
 const partnerId = getEcpParam("partnerId");
 const DEFAULT_SDK_PATH: string = "/embed/sdk.js";
-const sdkPath = getEcpParam("sdkPath") || DEFAULT_SDK_PATH;
 
 interface WealthProps {
   setLoading: (loading : boolean) => void;
@@ -35,7 +35,7 @@ const WealthApp = ({ setLoading } : WealthProps) => {
       return;
     }
     const sdkScriptNode = document.createElement("script");
-    sdkScriptNode.src = `https://${ecpOrigin}${sdkPath}`;
+    sdkScriptNode.src = `https://${ecpOrigin}${DEFAULT_SDK_PATH}`;
     sdkScriptNode.id = "symphony-ecm-sdk";
     sdkScriptNode.setAttribute("render", "explicit");
     sdkScriptNode.setAttribute("data-mode", "full");

--- a/AppExamples/CleverDeal.React/src/Components/LandingPage/LandingPage.scss
+++ b/AppExamples/CleverDeal.React/src/Components/LandingPage/LandingPage.scss
@@ -28,6 +28,7 @@
   display: flex;
   flex-direction: column;
   min-width: 10rem;
+  max-width: 10rem;
   min-height: 10rem;
   border: var(--on-background-color) 2px solid;
   border-radius: .5rem;

--- a/AppExamples/CleverDeal.React/src/Components/PodPicker/PodPicker.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/PodPicker/PodPicker.tsx
@@ -2,18 +2,27 @@ import { useEffect, useState, useMemo } from 'react';
 import Select from 'react-select';
 import './PodPicker.scss';
 import { getEcpParam } from '../../Utils/utils';
+import { ALLOWED_ORIGINS } from '../../Utils/originAllowlist';
 
 type OptionType = {
   value?: string
   label?: string
 }
 
+const POD_LABELS: Record<string, string> = {
+  'corporate.symphony.com': 'Corporate',
+  'preview.symphony.com': 'Preview',
+  'st3.dev.symphony.com': 'ST3',
+  'develop2.symphony.com': 'Develop2',
+};
+
 export const PodPicker = () => {
-  const options : OptionType[] = useMemo(() => [
-    { label: 'Corporate', value: 'corporate.symphony.com' },
-    { label: 'Preview', value: 'preview.symphony.com' },
-    { label: 'ST3', value: 'st3.dev.symphony.com' },
-  ], []);
+  const options : OptionType[] = useMemo(() =>
+    ALLOWED_ORIGINS.map(origin => ({
+      label: POD_LABELS[origin] || origin,
+      value: origin,
+    })),
+  []);
   const [ origin, setOrigin ] = useState<OptionType | null | undefined>(options[0]);
 
   useEffect(() => {

--- a/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/symphonySdk.test.ts
+++ b/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/symphonySdk.test.ts
@@ -292,6 +292,28 @@ test('injects the SDK script once in default focus mode without performing a hid
     expect(service.getRenderedStreamId('.slot-a')).toBe('stream-1');
   });
 
+  test('clears stale rendered state when the tracked client slot loses its iframe', async () => {
+    const service = new SymphonySdkService();
+    const openStreamMock = createOpenStreamMock();
+
+    (window as Window & { symphony?: unknown }).symphony = {
+      render: createRenderMock(),
+      openStream: openStreamMock,
+      sendMessage: jest.fn(),
+    } as any;
+
+    await service.init('corporate.symphony.com');
+    await service.openStream('stream-1', '.slot-a', { mode: 'light' });
+
+    expect(service.getRenderedStreamId('.slot-a')).toBe('stream-1');
+
+    const slot = document.querySelector('.slot-a') as HTMLDivElement;
+    slot.replaceChildren();
+
+    expect(service.hasRendered('.slot-a')).toBe(false);
+    expect(service.getRenderedStreamId('.slot-a')).toBeUndefined();
+  });
+
   test('waits for the warmed collaboration iframe to reload before resolving an openStream call', async () => {
     const service = new SymphonySdkService();
     const renderMock = createRenderMock();

--- a/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/symphonySdk.ts
+++ b/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/symphonySdk.ts
@@ -127,6 +127,38 @@ export class SymphonySdkService {
     return document.querySelector(containerSelector) as HTMLElement | null;
   }
 
+  private _getMountedFrame(containerSelector: string) {
+    const container = this._getContainer(containerSelector);
+    if (!container) {
+      return null;
+    }
+
+    return container.querySelector('iframe') as HTMLIFrameElement | null;
+  }
+
+  private _getLiveRenderedState(containerSelector: string) {
+    const trackedState = this._renderedContainers.get(containerSelector);
+    if (!trackedState) {
+      return undefined;
+    }
+
+    const container = this._getContainer(containerSelector);
+    const frame = container?.querySelector('iframe') as HTMLIFrameElement | null;
+
+    if (container && frame) {
+      return trackedState;
+    }
+
+    debugSdk('Clearing stale rendered container state.', {
+      containerSelector,
+      trackedStreamId: trackedState.streamId ?? null,
+      hasContainer: Boolean(container),
+      hasIframe: Boolean(frame),
+    });
+    this._renderedContainers.delete(containerSelector);
+    return undefined;
+  }
+
   private _getRenderTarget(containerSelector: string) {
     if (!containerSelector.startsWith('.')) {
       throw this._createError(`Symphony slot "${containerSelector}" must be a class selector.`);
@@ -526,13 +558,14 @@ export class SymphonySdkService {
         throw this._createError('Symphony SDK is not available on window.');
       }
 
-      const existingRender = this._renderedContainers.get(containerSelector);
-      const hasIframe = Boolean(container.querySelector('iframe'));
+      const existingRender = this._getLiveRenderedState(containerSelector);
+      const hasIframe = Boolean(this._getMountedFrame(containerSelector));
 
       debugSdk('renderChat() starting.', {
         containerSelector,
         streamId: requestedStreamId,
         hasExistingIframe: hasIframe,
+        trackedStreamId: existingRender?.streamId ?? null,
       });
 
       if (hasIframe && existingRender?.streamId === requestedStreamId) {
@@ -620,7 +653,7 @@ export class SymphonySdkService {
         window.symphony.updateTheme(renderOptions.theme as Record<string, unknown>);
       }
 
-      const existingRender = this._renderedContainers.get(containerSelector);
+      const existingRender = this._getLiveRenderedState(containerSelector);
       if (existingRender?.streamId === streamId) {
         debugSdk('openStream() skipped — already showing this stream.', { streamId });
         return;
@@ -629,7 +662,8 @@ export class SymphonySdkService {
       debugSdk('openStream() starting.', {
         streamId,
         containerSelector,
-        hadExistingFrame: Boolean(container.querySelector('iframe')),
+        hadExistingFrame: Boolean(this._getMountedFrame(containerSelector)),
+        trackedStreamId: existingRender?.streamId ?? null,
       });
 
       const frameWaitHandle = this._observeOpenedStream(containerSelector);
@@ -731,19 +765,11 @@ export class SymphonySdkService {
   }
 
   hasRendered(containerSelector: string) {
-    if (!this._getContainer(containerSelector)) {
-      return false;
-    }
-
-    return this._renderedContainers.has(containerSelector);
+    return Boolean(this._getLiveRenderedState(containerSelector));
   }
 
   getRenderedStreamId(containerSelector: string) {
-    if (!this._getContainer(containerSelector)) {
-      return undefined;
-    }
-
-    return this._renderedContainers.get(containerSelector)?.streamId;
+    return this._getLiveRenderedState(containerSelector)?.streamId;
   }
 
   adoptRenderedContainer(sourceSelector: string, targetSelector: string) {

--- a/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/symphonySdk.ts
+++ b/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/symphonySdk.ts
@@ -1,4 +1,5 @@
 import { debugWealth } from './wealthDebug';
+import { validateEcpOrigin } from '../../../Utils/originAllowlist';
 
 const SDK_SCRIPT_ID = 'symphony-ecm-sdk';
 const SDK_ONLOAD_CALLBACK = '__wealthManagementRenderEcp';
@@ -450,6 +451,7 @@ export class SymphonySdkService {
   }
 
   init(ecpOrigin: string, partnerId?: string): Promise<void> {
+    const validatedOrigin = validateEcpOrigin(ecpOrigin);
     if (this._status === 'ready') {
       debugSdk('init() skipped — already ready.');
       return Promise.resolve();
@@ -462,7 +464,7 @@ export class SymphonySdkService {
 
     const initStart = performance.now();
     debugSdk('init() starting.', {
-      ecpOrigin,
+      ecpOrigin: validatedOrigin,
       partnerId,
       hasSymphonyOnWindow: Boolean(window.symphony),
       hasExistingScript: Boolean(document.getElementById(SDK_SCRIPT_ID)),
@@ -512,7 +514,7 @@ export class SymphonySdkService {
       }
 
       const script = document.createElement('script');
-      script.src = `https://${ecpOrigin}${DEFAULT_SDK_PATH}`;
+      script.src = `https://${validatedOrigin}${DEFAULT_SDK_PATH}`;
       script.id = SDK_SCRIPT_ID;
       script.setAttribute('render', 'explicit');
       script.setAttribute('data-onload', SDK_ONLOAD_CALLBACK);
@@ -521,7 +523,7 @@ export class SymphonySdkService {
 
       if (partnerId) {
         script.setAttribute('data-partner-id', partnerId);
-      } else if (ecpOrigin !== 'st3.dev.symphony.com') {
+      } else if (validatedOrigin !== 'st3.dev.symphony.com') {
         script.setAttribute('data-partner-id', DEFAULT_PARTNER_ID);
       }
 

--- a/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/useClientChatSdkController.test.tsx
+++ b/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/useClientChatSdkController.test.tsx
@@ -26,6 +26,38 @@ let mockRenderedStreamId: string | undefined;
 let mockHasRendered = false;
 let mockIsReady = false;
 
+function mockGetSlot(containerSelector = '.wealth-symphony-client-contact') {
+  return document.querySelector(containerSelector) as HTMLDivElement | null;
+}
+
+function mockEnsureIframe(containerSelector: string, streamId?: string) {
+  const slot = mockGetSlot(containerSelector);
+  if (!slot) {
+    return;
+  }
+
+  let iframe = slot.querySelector('iframe') as HTMLIFrameElement | null;
+  if (!iframe) {
+    iframe = document.createElement('iframe');
+    slot.appendChild(iframe);
+  }
+
+  iframe.src = `https://corporate.symphony.com/apps/client2/${streamId ?? 'default'}`;
+}
+
+function mockSyncRenderedState(containerSelector = '.wealth-symphony-client-contact') {
+  const slot = mockGetSlot(containerSelector);
+  const iframe = slot?.querySelector('iframe') as HTMLIFrameElement | null;
+
+  if (!slot || !iframe) {
+    mockHasRendered = false;
+    mockRenderedStreamId = undefined;
+    return null;
+  }
+
+  return iframe;
+}
+
 jest.mock('./symphonySdk', () => ({
   symphonySdk: {
     init: async (ecpOrigin: string, partnerId?: string) => {
@@ -34,18 +66,26 @@ jest.mock('./symphonySdk', () => ({
     },
     renderChat: async (containerSelector: string, options: Record<string, unknown>) => {
       await mockRenderChat(containerSelector, options);
+      mockEnsureIframe(containerSelector, typeof options.streamId === 'string' ? options.streamId : undefined);
       mockHasRendered = true;
       mockRenderedStreamId = typeof options.streamId === 'string' ? options.streamId : undefined;
     },
     openStream: async (streamId: string, containerSelector: string, options?: Record<string, unknown>) => {
       await mockOpenStream(streamId, containerSelector, options);
+      mockEnsureIframe(containerSelector, streamId);
       mockHasRendered = true;
       mockRenderedStreamId = streamId;
     },
     sendMessage: (message: Record<string, unknown>, options: Record<string, unknown>) =>
       mockSendMessage(message, options),
-    hasRendered: () => mockHasRendered,
-    getRenderedStreamId: () => mockRenderedStreamId,
+    hasRendered: (containerSelector = '.wealth-symphony-client-contact') => {
+      return Boolean(mockSyncRenderedState(containerSelector) && mockHasRendered);
+    },
+    getRenderedStreamId: (containerSelector = '.wealth-symphony-client-contact') => {
+      return mockSyncRenderedState(containerSelector) && mockHasRendered
+        ? mockRenderedStreamId
+        : undefined;
+    },
     resetIfError: () => {
       const didReset = mockResetIfError();
       if (didReset) {
@@ -277,6 +317,39 @@ test('reuses the mounted client container when the drawer closes and reopens on 
   });
 
   expect(mockOpenStream).not.toHaveBeenCalled();
+});
+
+test('reopens the client stream when tracked state survives but the mounted slot lost its iframe', async () => {
+  const { rerender } = render(<HookHarness contactId="1" preload />);
+
+  await waitFor(() => {
+    expect(screen.getByTestId('status')).toHaveTextContent('ready');
+  });
+
+  const slot = document.querySelector('.wealth-symphony-client-contact') as HTMLDivElement | null;
+  expect(slot?.querySelector('iframe')).not.toBeNull();
+
+  slot?.replaceChildren();
+  mockOpenStream.mockClear();
+
+  rerender(<HookHarness contactId="1" enabled={false} preload />);
+  rerender(<HookHarness contactId="1" preload />);
+
+  await waitFor(() => {
+    expect(mockOpenStream).toHaveBeenCalledWith(
+      screen.getByTestId('stream-id').textContent ?? '',
+      '.wealth-symphony-client-contact',
+      expect.objectContaining({
+        condensed: false,
+        showMembers: false,
+        symphonyLogo: false,
+      }),
+    );
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('status')).toHaveTextContent('ready');
+  });
 });
 
 test('switches quickly to a new contact stream and sends messages through the active client slot', async () => {

--- a/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/useClientChatSdkController.ts
+++ b/AppExamples/CleverDeal.React/src/Components/WealthManagement/chat/useClientChatSdkController.ts
@@ -209,8 +209,13 @@ export function useClientChatSdkController({
       return;
     }
 
-    if (symphonySdk.getRenderedStreamId(containerSelector) === streamId) {
-      debugClientChat('Already showing requested stream — marking ready.', { streamId, containerSelector });
+    const renderedStreamId = symphonySdk.getRenderedStreamId(containerSelector);
+    if (renderedStreamId === streamId) {
+      debugClientChat('Already showing requested stream — marking ready.', {
+        streamId,
+        renderedStreamId,
+        containerSelector,
+      });
       setChatError(null);
       setIsChatReady(true);
       setIsLoading(false);
@@ -229,12 +234,14 @@ export function useClientChatSdkController({
       const startedAt = getNow();
 
       try {
+        const currentRenderedStreamId = symphonySdk.getRenderedStreamId(containerSelector);
         const hasWarmRenderedContainer = symphonySdk.hasRendered(containerSelector);
         debugClientChat('Opening client Symphony chat stream.', {
           attempt: attempt + 1,
           contactId,
           containerSelector,
           ecpOrigin,
+          currentRenderedStreamId: currentRenderedStreamId ?? null,
           hasWarmRenderedContainer,
           streamId,
         });

--- a/AppExamples/CleverDeal.React/src/Data/routes.ts
+++ b/AppExamples/CleverDeal.React/src/Data/routes.ts
@@ -1,7 +1,6 @@
 import CleverInvestments from "../Components/CleverInvestments";
 import CleverOperations from "../Components/CleverOperations";
 import CleverResearch from "../Components/CleverResearch";
-import CleverWealth from "../Components/CleverWealth";
 import ContentDistribution from "../Components/ContentDistribution";
 import WealthManagementRoute from "../Components/WealthManagement/WealthManagementRoute";
 
@@ -16,7 +15,6 @@ export const routes: AppEntry[] = [
   { label: "Investments",      path: "investments",      component: CleverInvestments },
   { label: "Operations",       path: "operations",       component: CleverOperations },
   { label: "Research",         path: "research",         component: CleverResearch },
-  { label: "Wealth",           path: "wealth",           component: CleverWealth },
-  { label: "Content",          path: "content",          component: ContentDistribution },
   { label: "Wealth Management", path: "wealth-management", routePath: "wealth-management/*", component: WealthManagementRoute, enabled: true },
+  { label: "Content",          path: "content",          component: ContentDistribution },
 ];

--- a/AppExamples/CleverDeal.React/src/Utils/originAllowlist.ts
+++ b/AppExamples/CleverDeal.React/src/Utils/originAllowlist.ts
@@ -1,0 +1,15 @@
+const DEFAULT_ORIGIN = 'corporate.symphony.com';
+
+export const ALLOWED_ORIGINS: readonly string[] = [
+  'corporate.symphony.com',
+  'preview.symphony.com',
+  'st3.dev.symphony.com',
+  'develop2.symphony.com',
+];
+
+export const validateEcpOrigin = (origin: string | null): string => {
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    return origin;
+  }
+  return DEFAULT_ORIGIN;
+};

--- a/AppExamples/CleverDeal.React/src/Utils/utils.js
+++ b/AppExamples/CleverDeal.React/src/Utils/utils.js
@@ -1,3 +1,4 @@
+import { validateEcpOrigin } from './originAllowlist';
 
 const SS_PREFIX = "cleverdeal::";
 
@@ -5,13 +6,24 @@ const SS_PREFIX = "cleverdeal::";
  * Get an ECP param from URL query params and store it in session storage.
  * If there is no such param in URL, use the one saved in session storage.
  * This prevents any ECP param loss after navigating through different URLs.
+ * Security: ecpOrigin values are validated against an allowlist before storage.
  * @param {*} name the ECP param name
  * @returns the ECP param value
  */
 export const getEcpParam = (name: string): string | null => {
     const sessionStorageKey = SS_PREFIX + name;
 
-    const queryParam = new URL(window.location.href).searchParams.get(name);
+    let queryParam = new URL(window.location.href).searchParams.get(name);
+
+    if (name === 'ecpOrigin') {
+        if (queryParam) {
+            queryParam = validateEcpOrigin(queryParam);
+        }
+        const stored = sessionStorage.getItem(sessionStorageKey);
+        if (stored && stored !== validateEcpOrigin(stored)) {
+            sessionStorage.removeItem(sessionStorageKey);
+        }
+    }
 
     if (queryParam) {
         sessionStorage.setItem(sessionStorageKey, queryParam);

--- a/AppExamples/CleverDeal.React/vercel.json
+++ b/AppExamples/CleverDeal.React/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;"
+        }
+      ]
+    }
+  ]
+}

--- a/AppExamples/CleverDeal.React/vercel.json
+++ b/AppExamples/CleverDeal.React/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;"
+          "value": "script-src 'self' https://*.symphony.com https://widgets.tradingview-widget.com 'unsafe-inline'; frame-src https://*.symphony.com https://*.tradingview-widget.com https://*.tradingview.com;"
         }
       ]
     }

--- a/AppExamples/CleverDealFDC3.React/public/index.html
+++ b/AppExamples/CleverDealFDC3.React/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/AppExamples/CleverDealFDC3.React/src/index.tsx
+++ b/AppExamples/CleverDealFDC3.React/src/index.tsx
@@ -5,7 +5,9 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 const DEFAULT_ORIGIN: string = "corporate.symphony.com";
-const originInParams = (new URL(window.location.href)).searchParams.get('ecpOrigin');
+const ALLOWED_ORIGINS = ['corporate.symphony.com', 'preview.symphony.com', 'st3.dev.symphony.com', 'develop2.symphony.com'];
+const rawOrigin = (new URL(window.location.href)).searchParams.get('ecpOrigin');
+const originInParams = rawOrigin && ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
 
 const loadSdk = (
 ): Promise<void> => {

--- a/AppExamples/EcpOpenSdk/public/index.html
+++ b/AppExamples/EcpOpenSdk/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; style-src 'self' https://cdn.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
 
     <title>ECP Open SDK example</title>
 

--- a/SimpleExamples/src/index-iframe.html
+++ b/SimpleExamples/src/index-iframe.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -47,9 +48,11 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "develop2.symphony.com";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
       function buildFrameUrl(streamId, userIds) {
         const locationUrl = new URL(location.href);
-        const sdkOrigin = locationUrl.searchParams.get("origin");
+        const rawOrigin = locationUrl.searchParams.get("origin");
+        const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
         const BASE_URL = `https://${
           sdkOrigin || DEFAULT_ORIGIN
         }/embed/index.html`;

--- a/SimpleExamples/src/index-multiple-chats.html
+++ b/SimpleExamples/src/index-multiple-chats.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -108,8 +109,10 @@
 
       const loadScript = () => {
         const DEFAULT_ORIGIN = "develop2.symphony.com";
+        const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
         const locationUrl = new URL(location.href);
-        const sdkOrigin = locationUrl.searchParams.get("origin");
+        const rawOrigin = locationUrl.searchParams.get("origin");
+        const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
         const script = document.createElement("script");
         script.id = "symphony-ecm-sdk";
         script.src = `https://${sdkOrigin || DEFAULT_ORIGIN}/embed/sdk.js`;

--- a/SimpleExamples/src/index-notifications.html
+++ b/SimpleExamples/src/index-notifications.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -91,8 +92,10 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "develop2.symphony.com";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
       const locationUrl = new URL(location.href);
-      const sdkOrigin = locationUrl.searchParams.get("origin");
+      const rawOrigin = locationUrl.searchParams.get("origin");
+      const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
 
       document
         .getElementById("ecp-form")

--- a/SimpleExamples/src/index-sdk-automatic.html
+++ b/SimpleExamples/src/index-sdk-automatic.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -72,8 +73,10 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "develop2.symphony.com";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
       const locationUrl = new URL(location.href);
-      const sdkOrigin = locationUrl.searchParams.get("origin");
+      const rawOrigin = locationUrl.searchParams.get("origin");
+      const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
       function cleanDOM(frameContainer) {
         frameContainer.removeAttribute("data-stream-id");
         frameContainer.removeAttribute("data-user-ids");

--- a/SimpleExamples/src/index-sdk-checkAuth.html
+++ b/SimpleExamples/src/index-sdk-checkAuth.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -81,8 +82,10 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "develop2.symphony.com";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
       const locationUrl = new URL(location.href);
-      const sdkOrigin = locationUrl.searchParams.get("origin");
+      const rawOrigin = locationUrl.searchParams.get("origin");
+      const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
 
       document
         .getElementById("ecp-form")

--- a/SimpleExamples/src/index-sdk-explicit.html
+++ b/SimpleExamples/src/index-sdk-explicit.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
 
@@ -90,8 +91,10 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "develop2.symphony.com";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
       const locationUrl = new URL(location.href);
-      const sdkOrigin = locationUrl.searchParams.get("origin");
+      const rawOrigin = locationUrl.searchParams.get("origin");
+      const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
 
       document
         .getElementById("ecp-form")

--- a/SimpleExamples/src/index-sdk-prefetch.html
+++ b/SimpleExamples/src/index-sdk-prefetch.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -107,8 +108,10 @@
 
       const loadScript = () => {
         const DEFAULT_ORIGIN = "develop2.symphony.com";
+        const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com"];
         const locationUrl = new URL(location.href);
-        const sdkOrigin = locationUrl.searchParams.get("origin");
+        const rawOrigin = locationUrl.searchParams.get("origin");
+        const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
         const script = document.createElement("script");
         script.id = "symphony-ecm-sdk";
         script.src = `https://${sdkOrigin || DEFAULT_ORIGIN}/embed/sdk.js`;

--- a/SimpleExamples/src/index-theme.html
+++ b/SimpleExamples/src/index-theme.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>ECP Demo</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -120,8 +121,10 @@
     </div>
     <script type="text/javascript">
       const DEFAULT_ORIGIN = "local-dev.symphony.com:9090";
+      const ALLOWED_ORIGINS = ["develop2.symphony.com", "corporate.symphony.com", "preview.symphony.com", "st3.dev.symphony.com", "local-dev.symphony.com:9090"];
       const locationUrl = new URL(location.href);
-      const sdkOrigin = locationUrl.searchParams.get("origin");
+      const rawOrigin = locationUrl.searchParams.get("origin");
+      const sdkOrigin = ALLOWED_ORIGINS.includes(rawOrigin) ? rawOrigin : null;
       document
         .getElementById("ecp-form")
         .addEventListener("submit", (event) => {


### PR DESCRIPTION
## Summary

Updates the Content Security Policy to allow TradingView widget scripts, fixing broken market mini-charts on the Wealth Management dashboard.

### Problem

The CSP `script-src` directive only permitted `'self'`, `https://*.symphony.com`, and `'unsafe-inline'`, which blocked the TradingView widget script (`https://widgets.tradingview-widget.com/w/en/tv-mini-chart.js`) from loading.

### Changes

- Added `https://widgets.tradingview-widget.com` to `script-src` to allow the TradingView chart script
- Added `https://*.tradingview-widget.com` and `https://*.tradingview.com` to `frame-src` to allow TradingView widget iframes

**Files updated:**
- `AppExamples/CleverDeal.React/public/index.html` — CSP meta tag
- `AppExamples/CleverDeal.React/vercel.json` — Vercel response header
- `AppExamples/CleverDeal.React/build/index.html` — pre-built copy