### PR TITLE
Fix CSP to allow TradingView widget scripts

### DIFF
--- a/AppExamples/CleverDeal.React/public/index.html
+++ b/AppExamples/CleverDeal.React/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://*.symphony.com https://widgets.tradingview-widget.com 'unsafe-inline'; frame-src https://*.symphony.com https://*.tradingview-widget.com https://*.tradingview.com;" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/AppExamples/CleverDeal.React/vercel.json
+++ b/AppExamples/CleverDeal.React/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "script-src 'self' https://*.symphony.com 'unsafe-inline'; frame-src https://*.symphony.com;"
+          "value": "script-src 'self' https://*.symphony.com https://widgets.tradingview-widget.com 'unsafe-inline'; frame-src https://*.symphony.com https://*.tradingview-widget.com https://*.tradingview.com;"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Updates the Content Security Policy to allow TradingView widget scripts, fixing broken market mini-charts on the Wealth Management dashboard.

### Problem

The CSP `script-src` directive only permitted `'self'`, `https://*.symphony.com`, and `'unsafe-inline'`, which blocked the TradingView widget script (`https://widgets.tradingview-widget.com/w/en/tv-mini-chart.js`) from loading.

### Changes

- Added `https://widgets.tradingview-widget.com` to `script-src` to allow the TradingView chart script
- Added `https://*.tradingview-widget.com` and `https://*.tradingview.com` to `frame-src` to allow TradingView widget iframes

**Files updated:**
- `AppExamples/CleverDeal.React/public/index.html` — CSP meta tag
- `AppExamples/CleverDeal.React/vercel.json` — Vercel response header

Replaces #52 (which had unrelated commits and merge conflicts).