### PR TITLE
feat: support silent blast display mode

### DIFF
--- a/SimpleExamples/src/index-blast-campaign-demo.html
+++ b/SimpleExamples/src/index-blast-campaign-demo.html
@@ -455,17 +455,13 @@
               <button class="btn" id="send-non-silent" type="button" disabled>
                 Send non-silent blast
               </button>
-              <!--
-                Silent blast support is expected at the end of June.
-                Uncomment this button when it is available.
-                <button class="btn btn-secondary" id="send-silent" type="button" disabled>
-                  Send silent blast
-                </button>
-              -->
+              <button class="btn btn-secondary" id="send-silent" type="button" disabled>
+                Send silent blast
+              </button>
             </div>
             <p class="availability-note">
-              Silent blast support is expected at the end of June; the code path
-              is present and the button is commented out for now.
+              Silent blast testing is enabled. The button becomes available when
+              the Symphony SDK is ready.
             </p>
             <div class="status" id="campaign-status" role="status"></div>
           </section>
@@ -780,7 +776,7 @@
 
         const options = {
           mode: "blast",
-          silent,
+          displayMode: silent ? "none" : "confirmation_dialog",
         };
 
         if (recipientType === "stream") {
@@ -812,7 +808,11 @@
         try {
           const message = await buildMessagePayload();
           const options = buildSendOptions(silent);
-          setStatus("Opening Symphony send dialog...");
+          setStatus(
+            silent
+              ? "Sending campaign without a confirmation dialog..."
+              : "Opening Symphony send dialog..."
+          );
 
           const sendPromise = Promise.resolve(
             window.symphony.sendMessage(message, options)
@@ -905,7 +905,6 @@
       sendNonSilentButton.addEventListener("click", () => sendBlast(false));
 
       if (silentButton) {
-        // The button is commented out until silent send is available.
         silentButton.addEventListener("click", () => sendBlast(true));
       }
 

--- a/SimpleExamples/src/index-blast-demo.html
+++ b/SimpleExamples/src/index-blast-demo.html
@@ -340,7 +340,7 @@
   },
   {
     mode: "blast",
-    silent: false,
+    displayMode: "confirmation_dialog", // Use "none" for silent send.
     users: [],
     streamIds: ["{ROOM_STREAM_ID}"],
   }
@@ -350,9 +350,6 @@
               <button class="btn" id="blast" type="button" disabled>
                 Send non-silent blast
               </button>
-              <!--
-                Silent blast support is expected at the end of June.
-                Uncomment this button when it is available.
               <button
                 class="btn btn-secondary"
                 id="silent-blast"
@@ -361,11 +358,10 @@
               >
                 Send silent blast
               </button>
-              -->
             </div>
             <p class="availability-note">
-              Silent blast support is expected at the end of June; the code path
-              is present and the button is commented out for now.
+              Non-silent sends show a confirmation dialog. Silent sends use
+              <code>displayMode: "none"</code> and send without a dialog.
             </p>
             <div class="status" id="blast-status" role="status"></div>
           </section>
@@ -499,7 +495,11 @@
         }
 
         setSending(true);
-        setStatus("Sending blast...");
+        setStatus(
+          silent
+            ? "Sending blast without a confirmation dialog..."
+            : "Opening Symphony send dialog..."
+        );
 
         try {
           await window.symphony.sendMessage(
@@ -510,7 +510,7 @@
             },
             {
               mode: "blast",
-              silent,
+              displayMode: silent ? "none" : "confirmation_dialog",
               users: [],
               streamIds,
             }
@@ -564,7 +564,6 @@
 
       blastButton.addEventListener("click", () => sendBlast(false));
       if (silentBlastButton) {
-        // The button is commented out until silent send is available.
         silentBlastButton.addEventListener("click", () => sendBlast(true));
       }
 


### PR DESCRIPTION
## What changed

- expose silent blast actions in both blast demos
- use displayMode: none for silent sends
- use displayMode: confirmation_dialog for non-silent sends
- update demo copy and status messages to reflect each behavior

## Why

The new SendMessageOptions contract replaces the unsupported silent flag with displayMode. Using the old flag caused the confirmation dialog to appear even for intended silent sends.

## Validation

- manually verified both display modes against develop2
- confirmed the branch contains one commit over current master
- git diff --check passes
- final diff: 2 files changed, 20 insertions, 22 deletions